### PR TITLE
updating niri-ipc dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ downcast-rs = "1.2.1"
 csscolorparser = "0.7.0"
 wayfire-rs = "0.2.2"
 serde_json = "1.0.135"
-niri-ipc = "=0.1.10"
+niri-ipc = "=25.11.0"
 handlebars = "6.3.0"
 serde = { version = "1.0.217", features = ["derive"] }
 reqwest = "0.12.12"


### PR DESCRIPTION
By updating the niri-ipc dependency the code does not warn for unknown Events which keeps CPU busy.