### PR TITLE
feat: add net upload/download speed modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ For a list of all currently supported modules, see [the Wiki](https://github.com
 - [x] wayfire workspace + window modules
 - [x] niri workspace + window modules
 - [x] basic bluetooth connections monitoring support
+- [x] basic wifi download/upload speed monitoring support
 - [ ] sway workspace + window modules
 - [ ] custom modules
-- [ ] additional modules (wifi, pacman updates...)
+- [ ] additional modules (pacman updates...)
 - [ ] system tray support
 - [ ] plugin api (for custom rust modules)
 - [ ] custom fonts

--- a/src/listeners/mod.rs
+++ b/src/listeners/mod.rs
@@ -3,6 +3,7 @@ use std::{any::Any, fmt::Debug};
 use downcast_rs::{Downcast, impl_downcast};
 use hyprland::HyprListener;
 use iced::Subscription;
+use net::NetListener;
 use niri::NiriListener;
 use reload::ReloadListener;
 use wayfire::WayfireListener;
@@ -10,6 +11,7 @@ use wayfire::WayfireListener;
 use crate::{Message, config::ConfigEntry, registry::Registry};
 
 pub mod hyprland;
+pub mod net;
 pub mod niri;
 mod reload;
 pub mod wayfire;
@@ -26,5 +28,6 @@ pub fn register_listeners(registry: &mut Registry) {
     registry.register_listener::<HyprListener>();
     registry.register_listener::<WayfireListener>();
     registry.register_listener::<NiriListener>();
+    registry.register_listener::<NetListener>();
     registry.register_listener::<ReloadListener>();
 }

--- a/src/listeners/net.rs
+++ b/src/listeners/net.rs
@@ -1,0 +1,110 @@
+use std::{fs, io, io::BufRead, time::Duration};
+
+use bar_rs_derive::Builder;
+use iced::{
+    Subscription,
+    futures::{SinkExt, channel::mpsc::Sender},
+    stream,
+};
+use tokio::time::sleep;
+
+use crate::{
+    Message,
+    modules::net::{NetDownloadMod, NetUploadMod},
+};
+
+use super::Listener;
+
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Builder)]
+pub struct NetListener;
+
+struct NetStats {
+    rx_bytes: u64,
+    tx_bytes: u64,
+}
+
+fn read_stats(iface: &str) -> Result<NetStats, io::Error> {
+    let file = fs::File::open("/proc/net/dev")?;
+    let reader = io::BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        let Some((name, data)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim() != iface {
+            continue;
+        }
+        let fields: Vec<&str> = data.split_whitespace().collect();
+        return Ok(NetStats {
+            rx_bytes: fields.first().and_then(|v| v.parse().ok()).unwrap_or(0),
+            tx_bytes: fields.get(8).and_then(|v| v.parse().ok()).unwrap_or(0),
+        });
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("interface {iface} not found in /proc/net/dev"),
+    ))
+}
+
+/// Find the interface used by the default route
+fn default_interface() -> Option<String> {
+    let file = fs::File::open("/proc/net/route").ok()?;
+    let reader = io::BufReader::new(file);
+    for line in reader.lines().map_while(Result::ok).skip(1) {
+        let mut fields = line.split_whitespace();
+        let iface = fields.next()?.to_string();
+        let destination = fields.next()?;
+        if destination == "00000000" {
+            return Some(iface);
+        }
+    }
+    None
+}
+
+impl Listener for NetListener {
+    fn subscription(&self) -> Subscription<Message> {
+        Subscription::run(|| {
+            stream::channel(1, |mut sender: Sender<Message>| async move {
+                let mut last = None;
+                loop {
+                    let Some(iface) = default_interface() else {
+                        sleep(SAMPLE_INTERVAL).await;
+                        continue;
+                    };
+                    let Ok(stats) = read_stats(&iface) else {
+                        sleep(SAMPLE_INTERVAL).await;
+                        continue;
+                    };
+                    let now = std::time::Instant::now();
+                    let (rx_speed, tx_speed) = match last {
+                        Some((prev_rx, prev_tx, prev_time)) => {
+                            let elapsed = now.duration_since(prev_time).as_secs_f32().max(0.001);
+                            (
+                                stats.rx_bytes.saturating_sub(prev_rx) as f32 / elapsed,
+                                stats.tx_bytes.saturating_sub(prev_tx) as f32 / elapsed,
+                            )
+                        }
+                        None => (0., 0.),
+                    };
+                    last = Some((stats.rx_bytes, stats.tx_bytes, now));
+                    sender
+                        .send(Message::update(move |reg| {
+                            let upload = reg.get_module_mut::<NetUploadMod>();
+                            upload.state.speed = tx_speed;
+                            upload.state.total = stats.tx_bytes;
+                            let download = reg.get_module_mut::<NetDownloadMod>();
+                            download.state.speed = rx_speed;
+                            download.state.total = stats.rx_bytes;
+                        }))
+                        .await
+                        .unwrap_or_else(|err| {
+                            eprintln!("Trying to send net speed failed with err: {err}")
+                        });
+                    sleep(SAMPLE_INTERVAL).await;
+                }
+            })
+        })
+    }
+}

--- a/src/listeners/net.rs
+++ b/src/listeners/net.rs
@@ -54,10 +54,10 @@ fn default_interface() -> Option<String> {
     let reader = io::BufReader::new(file);
     for line in reader.lines().map_while(Result::ok).skip(1) {
         let mut fields = line.split_whitespace();
-        let iface = fields.next()?.to_string();
+        let iface = fields.next()?;
         let destination = fields.next()?;
         if destination == "00000000" {
-            return Some(iface);
+            return Some(iface.to_string());
         }
     }
     None

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -21,6 +21,7 @@ use iced::{
 use iced::{Element, Subscription, widget::container::Style};
 use media::MediaMod;
 use memory::MemoryMod;
+use net::{NetDownloadMod, NetUploadMod};
 use niri::{NiriWindowMod, NiriWorkspaceMod};
 use time::TimeMod;
 use volume::VolumeMod;
@@ -43,6 +44,7 @@ pub mod empty;
 pub mod hyprland;
 pub mod media;
 pub mod memory;
+pub mod net;
 pub mod niri;
 pub mod time;
 pub mod volume;
@@ -228,6 +230,8 @@ pub fn register_modules(registry: &mut Registry) {
     registry.register_module::<WayfireWindowMod>();
     registry.register_module::<NiriWorkspaceMod>();
     registry.register_module::<NiriWindowMod>();
+    registry.register_module::<NetUploadMod>();
+    registry.register_module::<NetDownloadMod>();
 }
 
 #[macro_export]

--- a/src/modules/net.rs
+++ b/src/modules/net.rs
@@ -147,9 +147,9 @@ fn default_interface() -> Option<String> {
     let reader = BufReader::new(file);
     for line in reader.lines().map_while(Result::ok).skip(1) {
         let mut fields = line.split_whitespace();
-        let iface = fields.next()?.to_string();
         let destination = fields.next()?;
         if destination == "00000000" {
+            let iface = fields.next()?.to_string();
             return Some(iface);
         }
     }
@@ -198,7 +198,7 @@ impl NetModule for NetUploadMod {
 
 impl Module for NetUploadMod {
     fn name(&self) -> String {
-        "net_upload".to_string()
+        "net.upload".to_string()
     }
 
     fn view(
@@ -259,7 +259,7 @@ impl NetModule for NetDownloadMod {
 
 impl Module for NetDownloadMod {
     fn name(&self) -> String {
-        "net_download".to_string()
+        "net.download".to_string()
     }
 
     fn view(

--- a/src/modules/net.rs
+++ b/src/modules/net.rs
@@ -1,15 +1,7 @@
-use std::{
-    collections::HashMap,
-    fs,
-    io::{self, BufRead, BufReader},
-    time::Duration,
-};
+use std::collections::HashMap;
 
 use bar_rs_derive::Builder;
-use iced::{
-    Element, Subscription, futures::SinkExt, futures::channel::mpsc::Sender, stream, widget::text,
-};
-use tokio::time::sleep;
+use iced::{Element, widget::text};
 
 use crate::{
     Message, NERD_FONT,
@@ -19,22 +11,16 @@ use crate::{
     },
     fill::FillExt,
     impl_on_click, impl_wrapper,
+    listeners::net::NetListener,
 };
 
-use super::Module;
-
-const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
-
-enum Direction {
-    Rx,
-    Tx,
-}
+use super::{Module, require_listener};
 
 #[derive(Debug, Default)]
-struct NetState {
-    speed: f32,
-    total: u64,
-    icon: String,
+pub struct NetState {
+    pub speed: f32,
+    pub total: u64,
+    pub icon: String,
 }
 
 fn net_view<'a>(
@@ -77,85 +63,6 @@ fn read_config(
         .unwrap_or_else(|| state.icon.clone());
 }
 
-async fn net_loop<M: Module + NetModule>(sender: &mut Sender<Message>, direction: Direction) {
-    let mut last = None;
-    loop {
-        let Some(iface) = default_interface() else {
-            sleep(SAMPLE_INTERVAL).await;
-            continue;
-        };
-        let Ok(stats) = read_stats(&iface) else {
-            sleep(SAMPLE_INTERVAL).await;
-            continue;
-        };
-        let total = match direction {
-            Direction::Rx => stats.rx_bytes,
-            Direction::Tx => stats.tx_bytes,
-        };
-        let speed = match last {
-            Some((prev_total, prev_time)) => {
-                let elapsed = std::time::Instant::now().duration_since(prev_time);
-                let elapsed = elapsed.as_secs_f32().max(0.001);
-                (total.saturating_sub(prev_total)) as f32 / elapsed
-            }
-            None => 0.,
-        };
-        last = Some((total, std::time::Instant::now()));
-        sender
-            .send(Message::update(move |reg| {
-                let m = reg.get_module_mut::<M>();
-                m.state().speed = speed;
-                m.state().total = total;
-            }))
-            .await
-            .unwrap_or_else(|err| eprintln!("Trying to send net speed failed with err: {err}"));
-        sleep(SAMPLE_INTERVAL).await;
-    }
-}
-
-struct NetStats {
-    rx_bytes: u64,
-    tx_bytes: u64,
-}
-
-fn read_stats(iface: &str) -> Result<NetStats, io::Error> {
-    let file = fs::File::open("/proc/net/dev")?;
-    let reader = BufReader::new(file);
-    for line in reader.lines() {
-        let line = line?;
-        let Some((name, data)) = line.split_once(':') else {
-            continue;
-        };
-        if name.trim() != iface {
-            continue;
-        }
-        let fields: Vec<&str> = data.split_whitespace().collect();
-        return Ok(NetStats {
-            rx_bytes: fields.first().and_then(|v| v.parse().ok()).unwrap_or(0),
-            tx_bytes: fields.get(8).and_then(|v| v.parse().ok()).unwrap_or(0),
-        });
-    }
-    Err(io::Error::new(
-        io::ErrorKind::NotFound,
-        format!("interface {iface} not found in /proc/net/dev"),
-    ))
-}
-
-/// Find the interface used by the default route
-fn default_interface() -> Option<String> {
-    let file = fs::File::open("/proc/net/route").ok()?;
-    let reader = BufReader::new(file);
-    for line in reader.lines().map_while(Result::ok).skip(1) {
-        let mut fields = line.split_whitespace();
-        let destination = fields.next()?;
-        if destination == "00000000" {
-            let iface = fields.next()?.to_string();
-            return Some(iface);
-        }
-    }
-    None
-}
-
 /// Format a byte rate, e.g. `1.5 MB/s`.
 fn format_speed(speed: f32) -> String {
     let (value, unit) = if speed >= 1024. * 1024. {
@@ -168,13 +75,9 @@ fn format_speed(speed: f32) -> String {
     format!("{value:.1} {unit}")
 }
 
-trait NetModule {
-    fn state(&mut self) -> &mut NetState;
-}
-
 #[derive(Debug, Builder)]
 pub struct NetUploadMod {
-    state: NetState,
+    pub state: NetState,
     cfg_override: ModuleConfigOverride,
 }
 
@@ -187,12 +90,6 @@ impl Default for NetUploadMod {
             },
             cfg_override: Default::default(),
         }
-    }
-}
-
-impl NetModule for NetUploadMod {
-    fn state(&mut self) -> &mut NetState {
-        &mut self.state
     }
 }
 
@@ -213,6 +110,10 @@ impl Module for NetUploadMod {
 
     impl_wrapper!();
 
+    fn requires(&self) -> Vec<std::any::TypeId> {
+        vec![require_listener::<NetListener>()]
+    }
+
     fn read_config(
         &mut self,
         config: &HashMap<String, Option<String>>,
@@ -223,19 +124,11 @@ impl Module for NetUploadMod {
     }
 
     impl_on_click!();
-
-    fn subscription(&self) -> Option<iced::Subscription<Message>> {
-        Some(Subscription::run(|| {
-            stream::channel(1, |mut sender: Sender<Message>| async move {
-                net_loop::<Self>(&mut sender, Direction::Tx).await;
-            })
-        }))
-    }
 }
 
 #[derive(Debug, Builder)]
 pub struct NetDownloadMod {
-    state: NetState,
+    pub state: NetState,
     cfg_override: ModuleConfigOverride,
 }
 
@@ -248,12 +141,6 @@ impl Default for NetDownloadMod {
             },
             cfg_override: Default::default(),
         }
-    }
-}
-
-impl NetModule for NetDownloadMod {
-    fn state(&mut self) -> &mut NetState {
-        &mut self.state
     }
 }
 
@@ -274,6 +161,10 @@ impl Module for NetDownloadMod {
 
     impl_wrapper!();
 
+    fn requires(&self) -> Vec<std::any::TypeId> {
+        vec![require_listener::<NetListener>()]
+    }
+
     fn read_config(
         &mut self,
         config: &HashMap<String, Option<String>>,
@@ -284,12 +175,4 @@ impl Module for NetDownloadMod {
     }
 
     impl_on_click!();
-
-    fn subscription(&self) -> Option<iced::Subscription<Message>> {
-        Some(Subscription::run(|| {
-            stream::channel(1, |mut sender: Sender<Message>| async move {
-                net_loop::<Self>(&mut sender, Direction::Rx).await;
-            })
-        }))
-    }
 }

--- a/src/modules/net.rs
+++ b/src/modules/net.rs
@@ -1,0 +1,295 @@
+use std::{
+    collections::HashMap,
+    fs,
+    io::{self, BufRead, BufReader},
+    time::Duration,
+};
+
+use bar_rs_derive::Builder;
+use iced::{
+    Element, Subscription, futures::SinkExt, futures::channel::mpsc::Sender, stream, widget::text,
+};
+use tokio::time::sleep;
+
+use crate::{
+    Message, NERD_FONT,
+    config::{
+        anchor::BarAnchor,
+        module_config::{LocalModuleConfig, ModuleConfigOverride},
+    },
+    fill::FillExt,
+    impl_on_click, impl_wrapper,
+};
+
+use super::Module;
+
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+
+enum Direction {
+    Rx,
+    Tx,
+}
+
+#[derive(Debug, Default)]
+struct NetState {
+    speed: f32,
+    total: u64,
+    icon: String,
+}
+
+fn net_view<'a>(
+    state: &'a NetState,
+    cfg_override: &ModuleConfigOverride,
+    config: &LocalModuleConfig,
+    anchor: &BarAnchor,
+) -> Element<'a, Message> {
+    list![
+        anchor,
+        iced::widget::container(
+            text!("{}", state.icon)
+                .fill(anchor)
+                .size(cfg_override.icon_size.unwrap_or(config.icon_size))
+                .color(cfg_override.icon_color.unwrap_or(config.icon_color))
+                .font(NERD_FONT)
+        )
+        .padding(cfg_override.icon_margin.unwrap_or(config.icon_margin)),
+        iced::widget::container(
+            text!("{}", format_speed(state.speed))
+                .fill(anchor)
+                .size(cfg_override.font_size.unwrap_or(config.font_size))
+                .color(cfg_override.text_color.unwrap_or(config.text_color))
+        )
+        .padding(cfg_override.text_margin.unwrap_or(config.text_margin)),
+    ]
+    .spacing(cfg_override.spacing.unwrap_or(config.spacing))
+    .into()
+}
+
+fn read_config(
+    state: &mut NetState,
+    cfg_override: &mut ModuleConfigOverride,
+    config: &HashMap<String, Option<String>>,
+) {
+    *cfg_override = config.into();
+    state.icon = config
+        .get("icon")
+        .and_then(|v| v.clone())
+        .unwrap_or_else(|| state.icon.clone());
+}
+
+async fn net_loop<M: Module + NetModule>(sender: &mut Sender<Message>, direction: Direction) {
+    let mut last = None;
+    loop {
+        let Some(iface) = default_interface() else {
+            sleep(SAMPLE_INTERVAL).await;
+            continue;
+        };
+        let Ok(stats) = read_stats(&iface) else {
+            sleep(SAMPLE_INTERVAL).await;
+            continue;
+        };
+        let total = match direction {
+            Direction::Rx => stats.rx_bytes,
+            Direction::Tx => stats.tx_bytes,
+        };
+        let speed = match last {
+            Some((prev_total, prev_time)) => {
+                let elapsed = std::time::Instant::now().duration_since(prev_time);
+                let elapsed = elapsed.as_secs_f32().max(0.001);
+                (total.saturating_sub(prev_total)) as f32 / elapsed
+            }
+            None => 0.,
+        };
+        last = Some((total, std::time::Instant::now()));
+        sender
+            .send(Message::update(move |reg| {
+                let m = reg.get_module_mut::<M>();
+                m.state().speed = speed;
+                m.state().total = total;
+            }))
+            .await
+            .unwrap_or_else(|err| eprintln!("Trying to send net speed failed with err: {err}"));
+        sleep(SAMPLE_INTERVAL).await;
+    }
+}
+
+struct NetStats {
+    rx_bytes: u64,
+    tx_bytes: u64,
+}
+
+fn read_stats(iface: &str) -> Result<NetStats, io::Error> {
+    let file = fs::File::open("/proc/net/dev")?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        let Some((name, data)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim() != iface {
+            continue;
+        }
+        let fields: Vec<&str> = data.split_whitespace().collect();
+        return Ok(NetStats {
+            rx_bytes: fields.first().and_then(|v| v.parse().ok()).unwrap_or(0),
+            tx_bytes: fields.get(8).and_then(|v| v.parse().ok()).unwrap_or(0),
+        });
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("interface {iface} not found in /proc/net/dev"),
+    ))
+}
+
+/// Find the interface used by the default route
+fn default_interface() -> Option<String> {
+    let file = fs::File::open("/proc/net/route").ok()?;
+    let reader = BufReader::new(file);
+    for line in reader.lines().map_while(Result::ok).skip(1) {
+        let mut fields = line.split_whitespace();
+        let iface = fields.next()?.to_string();
+        let destination = fields.next()?;
+        if destination == "00000000" {
+            return Some(iface);
+        }
+    }
+    None
+}
+
+/// Format a byte rate, e.g. `1.5 MB/s`.
+fn format_speed(speed: f32) -> String {
+    let (value, unit) = if speed >= 1024. * 1024. {
+        (speed / (1024. * 1024.), "MB/s")
+    } else if speed >= 1024. {
+        (speed / 1024., "KB/s")
+    } else {
+        (speed, "B/s")
+    };
+    format!("{value:.1} {unit}")
+}
+
+trait NetModule {
+    fn state(&mut self) -> &mut NetState;
+}
+
+#[derive(Debug, Builder)]
+pub struct NetUploadMod {
+    state: NetState,
+    cfg_override: ModuleConfigOverride,
+}
+
+impl Default for NetUploadMod {
+    fn default() -> Self {
+        Self {
+            state: NetState {
+                icon: "󰕒".to_string(),
+                ..Default::default()
+            },
+            cfg_override: Default::default(),
+        }
+    }
+}
+
+impl NetModule for NetUploadMod {
+    fn state(&mut self) -> &mut NetState {
+        &mut self.state
+    }
+}
+
+impl Module for NetUploadMod {
+    fn name(&self) -> String {
+        "net_upload".to_string()
+    }
+
+    fn view(
+        &self,
+        config: &LocalModuleConfig,
+        _popup_config: &crate::config::popup_config::PopupConfig,
+        anchor: &BarAnchor,
+        _handlebars: &handlebars::Handlebars,
+    ) -> Element<'_, Message> {
+        net_view(&self.state, &self.cfg_override, config, anchor)
+    }
+
+    impl_wrapper!();
+
+    fn read_config(
+        &mut self,
+        config: &HashMap<String, Option<String>>,
+        _popup_config: &HashMap<String, Option<String>>,
+        _templates: &mut handlebars::Handlebars,
+    ) {
+        read_config(&mut self.state, &mut self.cfg_override, config);
+    }
+
+    impl_on_click!();
+
+    fn subscription(&self) -> Option<iced::Subscription<Message>> {
+        Some(Subscription::run(|| {
+            stream::channel(1, |mut sender: Sender<Message>| async move {
+                net_loop::<Self>(&mut sender, Direction::Tx).await;
+            })
+        }))
+    }
+}
+
+#[derive(Debug, Builder)]
+pub struct NetDownloadMod {
+    state: NetState,
+    cfg_override: ModuleConfigOverride,
+}
+
+impl Default for NetDownloadMod {
+    fn default() -> Self {
+        Self {
+            state: NetState {
+                icon: "󰇚".to_string(),
+                ..Default::default()
+            },
+            cfg_override: Default::default(),
+        }
+    }
+}
+
+impl NetModule for NetDownloadMod {
+    fn state(&mut self) -> &mut NetState {
+        &mut self.state
+    }
+}
+
+impl Module for NetDownloadMod {
+    fn name(&self) -> String {
+        "net_download".to_string()
+    }
+
+    fn view(
+        &self,
+        config: &LocalModuleConfig,
+        _popup_config: &crate::config::popup_config::PopupConfig,
+        anchor: &BarAnchor,
+        _handlebars: &handlebars::Handlebars,
+    ) -> Element<'_, Message> {
+        net_view(&self.state, &self.cfg_override, config, anchor)
+    }
+
+    impl_wrapper!();
+
+    fn read_config(
+        &mut self,
+        config: &HashMap<String, Option<String>>,
+        _popup_config: &HashMap<String, Option<String>>,
+        _templates: &mut handlebars::Handlebars,
+    ) {
+        read_config(&mut self.state, &mut self.cfg_override, config);
+    }
+
+    impl_on_click!();
+
+    fn subscription(&self) -> Option<iced::Subscription<Message>> {
+        Some(Subscription::run(|| {
+            stream::channel(1, |mut sender: Sender<Message>| async move {
+                net_loop::<Self>(&mut sender, Direction::Rx).await;
+            })
+        }))
+    }
+}

--- a/wiki/Modules.md
+++ b/wiki/Modules.md
@@ -15,6 +15,8 @@ The following modules are currently available:
 | ------ | ----------- |
 | [cpu](./Modules:-CPU.md) | Shows the current CPU usage |
 | [memory](./Modules:-Memory.md) | Shows the current memory usage |
+| [net.upload](./Modules:-Net.md) | Shows the current upload speed |
+| [net.download](./Modules:-Net.md) | Shows the current download speed |
 | [time](./Modules:-Date-and-Time.md) | Shows the local time |
 | [date](./Modules:-Date-and-Time.md) | Shows the local date |
 | [battery](./Modules:-Battery.md) | Shows the current capacity and remaining time |

--- a/wiki/Modules:-Net.md
+++ b/wiki/Modules:-Net.md
@@ -1,0 +1,12 @@
+# Net
+Names: `net.upload`, `net.download`
+
+Shows the current network transfer speed. `net.upload` shows the upload speed, `net.download` shows the download speed.<br>
+Both modules are updated once per second by a shared listener which reads stats from `/proc/net/dev` for the interface used by the default route (found in `/proc/net/route`), see [kernel.org](https://docs.kernel.org/filesystems/proc.html#network-device-information).
+
+You can override the default settings defined in [Module Styling](./Modules.md) by setting them in this section: `module:net.upload` or `module:net.download`.
+| Option | Description | Data type | Default |
+| ------ | ----------- | --------- | ------- |
+| icon | the icon to use | String | 󰕒 for `net.upload`, 󰇚 for `net.download` |
+
+The speed is displayed in `B/s`, `KB/s` or `MB/s` depending on its magnitude.


### PR DESCRIPTION
Two independent modules (net_upload, net_download) sampling /proc/net/dev every second to show transfer speed of the default route interface. Units auto-scale between B/s, KB/s and MB/s.