### PR TITLE
fix: kill subscription child processes on drop

### DIFF
--- a/src/modules/media.rs
+++ b/src/modules/media.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use crate::{impl_on_click, impl_wrapper};
 
-use super::{KillOnDrop, Module};
+use super::Module;
 
 #[derive(Debug, Builder)]
 pub struct MediaMod {
@@ -485,6 +485,7 @@ impl Module for MediaMod {
                         "playerctl --follow metadata --format '{\"title\": \"{{title}}\", \"artist\": \"{{artist}}\", \"album\": \"{{album}}\", \"art_url\": \"{{mpris:artUrl}}\", \"length\": {{mpris:length}}, \"status\": \"{{status}}\", \"player\": \"{{playerName}}\"}'",
                     )
                     .stdout(Stdio::piped())
+                    .kill_on_drop(true)
                     .spawn()
                     .expect("Failed to read output from playerctl");
 
@@ -492,10 +493,6 @@ impl Module for MediaMod {
                     .stdout
                     .take()
                     .expect("child did not have a handle to stdout");
-
-                // Kill playerctl when the subscription ends (e.g. on reload),
-                // so it doesn't leak and accumulate processes.
-                let _kill_on_drop = KillOnDrop(child);
 
                 let mut reader = BufReader::new(stdout).lines();
                 let mut last_track = String::new();

--- a/src/modules/media.rs
+++ b/src/modules/media.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use crate::{impl_on_click, impl_wrapper};
 
-use super::Module;
+use super::{KillOnDrop, Module};
 
 #[derive(Debug, Builder)]
 pub struct MediaMod {
@@ -492,6 +492,10 @@ impl Module for MediaMod {
                     .stdout
                     .take()
                     .expect("child did not have a handle to stdout");
+
+                // Kill playerctl when the subscription ends (e.g. on reload),
+                // so it doesn't leak and accumulate processes.
+                let _kill_on_drop = KillOnDrop(child);
 
                 let mut reader = BufReader::new(stdout).lines();
                 let mut last_track = String::new();

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -160,17 +160,6 @@ pub trait Module: Any + Debug + Send + Sync + Downcast {
 }
 impl_downcast!(Module);
 
-/// Kills the wrapped child process when dropped, so subscription child
-/// processes (e.g. `pactl subscribe`, `playerctl --follow`) don't leak when
-/// the subscription ends (e.g. on config reload).
-pub struct KillOnDrop(pub tokio::process::Child);
-
-impl Drop for KillOnDrop {
-    fn drop(&mut self) {
-        let _ = self.0.start_kill();
-    }
-}
-
 pub trait Action: Any + Debug + Send + Sync + Downcast {
     fn as_message(&self) -> Message;
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -160,6 +160,17 @@ pub trait Module: Any + Debug + Send + Sync + Downcast {
 }
 impl_downcast!(Module);
 
+/// Kills the wrapped child process when dropped, so subscription child
+/// processes (e.g. `pactl subscribe`, `playerctl --follow`) don't leak when
+/// the subscription ends (e.g. on config reload).
+pub struct KillOnDrop(pub tokio::process::Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.start_kill();
+    }
+}
+
 pub trait Action: Any + Debug + Send + Sync + Downcast {
     fn as_message(&self) -> Message;
 }

--- a/src/modules/volume.rs
+++ b/src/modules/volume.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use crate::{impl_on_click, impl_wrapper};
 
-use super::Module;
+use super::{KillOnDrop, Module};
 
 #[derive(Default, Debug, Builder)]
 pub struct VolumeMod {
@@ -108,6 +108,10 @@ impl Module for VolumeMod {
                     .stdout
                     .take()
                     .expect("child did not have a handle to stdout");
+
+                // Kill pactl when the subscription ends (e.g. on reload), so
+                // it doesn't leak and exhaust the pulse client limit.
+                let _kill_on_drop = KillOnDrop(child);
 
                 let mut reader = BufReader::new(stdout).lines();
 

--- a/src/modules/volume.rs
+++ b/src/modules/volume.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use crate::{impl_on_click, impl_wrapper};
 
-use super::{KillOnDrop, Module};
+use super::Module;
 
 #[derive(Default, Debug, Builder)]
 pub struct VolumeMod {
@@ -100,6 +100,7 @@ impl Module for VolumeMod {
                 let mut child = Command::new("sh")
                     .arg("-c")
                     .arg("pactl subscribe")
+                    .kill_on_drop(true)
                     .stdout(Stdio::piped())
                     .spawn()
                     .expect("Failed to spawn pactl to monitor volume changes");
@@ -108,10 +109,6 @@ impl Module for VolumeMod {
                     .stdout
                     .take()
                     .expect("child did not have a handle to stdout");
-
-                // Kill pactl when the subscription ends (e.g. on reload), so
-                // it doesn't leak and exhaust the pulse client limit.
-                let _kill_on_drop = KillOnDrop(child);
 
                 let mut reader = BufReader::new(stdout).lines();
 


### PR DESCRIPTION
pactl subscribe (volume) and playerctl --follow (media) child processes were never terminated when their subscription ended, leaking one orphan per reload and eventually exhausting the pulse client limit.